### PR TITLE
Extra "plus" in compressToEncodedURIComponent output

### DIFF
--- a/src/main/java/blazing/chain/LZSEncoding.java
+++ b/src/main/java/blazing/chain/LZSEncoding.java
@@ -97,7 +97,7 @@ public final class LZSEncoding {
     public static String compressToEncodedURIComponent(String uncompressed) {
         if (uncompressed == null)
             return null;
-        return _compress(uncompressed, 6, keyStrUriSafe, 0) + '+';
+        return _compress(uncompressed, 6, keyStrUriSafe, 0);
     }
     /**
      * Decompresses a String that had been compressed with {@link #compressToEncodedURIComponent(String)}.


### PR DESCRIPTION
Hey! 
I compared output of javascript library and find strange `+` at the end of `compressToEncodedURIComponent` output.

And I don't see it in the javascript version:
https://github.com/pieroxy/lz-string/blob/f91287282a0c3ecded46780168a6ff34b49f5eae/libs/lz-string.js#L95

(And there is no such extra plus in similar java port)
https://github.com/rufushuang/lz-string4java/blob/fb6d5d489ef8b747340244c74d30710b63435773/src/rufus/lzstring4java/LZString.java#L93


My guess is this ending "+" (which previously was ending " ") was added by mistake (from similar method `compressToUTF16`).